### PR TITLE
Hide BP Doc meta

### DIFF
--- a/assets/css/style-overrides.css
+++ b/assets/css/style-overrides.css
@@ -487,6 +487,11 @@ textarea#comment
 	width: 100%;
 }
 
+#doc-meta
+{
+	display: none;
+}
+
 
 
 /* WP Chat */


### PR DESCRIPTION
Hides the two meta boxes via CSS so as to preserve the POST data and not upset BP Docs save routine
